### PR TITLE
Ensure manual inputs update sliders

### DIFF
--- a/app.js
+++ b/app.js
@@ -80,12 +80,14 @@ historicalData.forEach((rec,idx)=>{
   number.addEventListener("blur",e=>{
     const v=parseFloat(e.target.value.replace(/[^0-9.]/g,""))||0;
     investmentAmounts[idx]=v;
+    slider.value=v;             // keep slider in sync with manual entry
     e.target.value=fmtCur(v);
     updateCalculation();
   });
   number.addEventListener("input",e=>{
     const v=parseFloat(e.target.value.replace(/[^0-9.]/g,""))||0;
     investmentAmounts[idx]=v;
+    slider.value=v;             // reflect typed value immediately
     updateCalculation();
   });
 });


### PR DESCRIPTION
## Summary
- Sync slider positions with typed investment amounts
- Reflect manual entries immediately in both range sliders and calculations

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6896285764a8832690700173b1bbbed0