### PR TITLE
Add chart download buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,7 @@
               <div class="card-body d-flex flex-column">
                 <h2 class="card-title">Stock Value Over Time</h2>
                 <div id="chart" style="width:100%;height:450px;"></div>
+                <button id="downloadMainChart" class="btn btn-secondary mt-2">Download Chart</button>
 
                 <div id="summaryScrollContainer"
                      class="table-responsive mt-3 flex-grow-1">
@@ -231,6 +232,7 @@
                 <h2 class="card-title">Projected Growth</h2>
                 <div id="scenarioChart"
                      style="width:100%;height:450px;"></div>
+                <button id="downloadProjectionChart" class="btn btn-secondary mt-2">Download Chart</button>
 
                 <div class="table-responsive mt-3 flex-grow-1">
                   <table id="projectionTable" class="table table-bordered mb-0">

--- a/js/ui.js
+++ b/js/ui.js
@@ -177,4 +177,19 @@ function exportDetailedTable(){
   URL.revokeObjectURL(link.href);
 }
 
-document.getElementById('exportCSV').addEventListener('click',exportDetailedTable);
+  document.getElementById('exportCSV').addEventListener('click',exportDetailedTable);
+
+function downloadMainChart(){
+  Plotly.downloadImage(document.getElementById('chart'),{
+    format:'png',filename:'stock_value_over_time'
+  });
+}
+
+function downloadProjectionChart(){
+  Plotly.downloadImage(document.getElementById('scenarioChart'),{
+    format:'png',filename:'projected_growth'
+  });
+}
+
+document.getElementById('downloadMainChart').addEventListener('click',downloadMainChart);
+document.getElementById('downloadProjectionChart').addEventListener('click',downloadProjectionChart);


### PR DESCRIPTION
## Summary
- add download buttons under primary and projection charts
- implement download handlers using Plotly.downloadImage

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/stockgraph/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68963e119e0c83268fa447f681ff7181