### PR TITLE
Handle projected tab display in Stockgraph

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -193,6 +193,10 @@ document.getElementById('goToProjectionBtn').addEventListener('click',()=>{
   new bootstrap.Tab(document.getElementById('projected-tab')).show();
 });
 
+document.getElementById('projected-tab').addEventListener('shown.bs.tab', () => {
+  updateScenarioComparison();
+});
+
 const annualInput=document.getElementById('annualPurchase');
 ['projectionYears','conservativeRate','baseRate','aggressiveRate'].forEach(
  id=>document.getElementById(id).addEventListener('input',()=>{


### PR DESCRIPTION
## Summary
- Resize scenario chart when switching to the Projected Growth tab by listening for Bootstrap's `shown.bs.tab` event

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68964f0b378083269b5e93fd2b5430d9