### PR TITLE
Make Projected Growth layout responsive on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
       <div class="tab-pane fade" id="projected" role="tabpanel" aria-labelledby="projected-tab">
         <div class="row g-3 align-items-start flex-lg-nowrap mt-4">
           <!-- Scenario Settings (shrink‑wrap column) -->
-          <div class="col-auto">
+          <div class="col-12 col-lg-auto">
             <div class="card scenario-card">
               <div class="card-body">
                 <h2 class="card-title">Scenario Settings</h2>
@@ -226,7 +226,7 @@
           </div>
 
           <!-- Projected Growth chart & table -->
-          <div class="col projected-chart-col">
+          <div class="col-12 col-lg projected-chart-col">
             <div class="card h-100">
               <div class="card-body d-flex flex-column">
                 <h2 class="card-title">Projected Growth</h2>

--- a/styles.css
+++ b/styles.css
@@ -156,6 +156,13 @@ body {
   min-height: 0;
 }
 
+/* Adjust chart height on narrow devices */
+@media (max-width: 576px) {
+  #scenarioChart {
+    height: 300px;
+  }
+}
+
 /* Footer */
 footer {
   text-align: center;


### PR DESCRIPTION
## Summary
- ensure Scenario Settings and chart stack vertically on small screens
- adjust chart height with small-screen media query

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689761428fd08326891a00e6348e5b85