### PR TITLE
Relocate navigation buttons below tab content

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,19 +68,11 @@
                   Purchases assumed to be in April of the following year at the new stock price
                 </p>
 
-                <!-- Buttons Row -->
-                <div class="d-flex justify-content-between mb-3 flex-wrap">
+                <!-- Snap Button -->
+                <div class="mb-3">
                   <button id="snapBtn"
-                          class="btn btn-secondary flex-grow-1 me-2 mb-2">
+                          class="btn btn-secondary w-100">
                     Snap Investments to Stock Price
-                  </button>
-                  <button id="goToDetailsBtn"
-                          class="btn btn-secondary me-2 mb-2">
-                    Go to Details
-                  </button>
-                  <button id="goToProjectionBtn"
-                          class="btn btn-secondary mb-2">
-                    Go to Projected Growth
                   </button>
                 </div>
 
@@ -252,7 +244,13 @@
           </div>
         </div><!-- /row -->
       </div><!-- /projected tab -->
-  </div><!-- /tab-content -->
+    </div><!-- /tab-content -->
+
+    <!-- Navigation Buttons -->
+    <div class="d-flex justify-content-end gap-2 mt-3">
+      <button id="goToDetailsBtn" class="btn btn-secondary">Go to Details</button>
+      <button id="goToProjectionBtn" class="btn btn-secondary">Go to Projected Growth</button>
+    </div>
   </div><!-- /container -->
 
   <footer class="text-muted small text-center mt-4">


### PR DESCRIPTION
## Summary
- Move "Go to Details" and "Go to Projected Growth" controls out of the investment panel and place them in a dedicated navigation section beneath the tab content.
- Keep the snap button within the investment panel, simplifying the surrounding markup.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/stockgraph/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_6897633d758883268f54b2d5276cc70a