### PR TITLE
Make dashboard tabs scrollable on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
 
   <!-- ── Tab Bar ──────────────────────────────────────────────── -->
   <div class="container-fluid mt-4">
-    <ul class="nav nav-tabs rounded-tabs" id="dashboardTabs" role="tablist">
+    <ul class="nav nav-tabs rounded-tabs flex-nowrap overflow-auto" id="dashboardTabs" role="tablist">
       <li class="nav-item">
         <button class="nav-link active" id="historical-tab"
                 data-bs-toggle="tab" data-bs-target="#historical"

--- a/styles.css
+++ b/styles.css
@@ -28,10 +28,20 @@ body {
   border-radius: 0.75rem 0.75rem 0 0;
   color: var(--main-green) !important;
 }
+
 .rounded-tabs .nav-link.active {
   background: #fff;
   border: 1px solid var(--main-green);
   border-bottom-color: #fff;
+}
+
+#dashboardTabs {
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+#dashboardTabs .nav-link {
+  white-space: nowrap;
 }
 
 /* Cards & tables */


### PR DESCRIPTION
## Summary
- Add responsive classes to dashboard tab list so tabs stay on one line and can scroll horizontally.
- Introduce CSS to disable wrapping and enable sideways scrolling in the tab bar.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68976349142c8326ad2b1312e553c57f