### PR TITLE
Disable Plotly interactivity in calculator charts

### DIFF
--- a/js/calculator.js
+++ b/js/calculator.js
@@ -91,7 +91,7 @@ export function updateCalculation(){
     yaxis:{title:'Value\u00A0($)'},
     legend:{orientation:'h',x:0,xanchor:'left',y:-.25},
     margin:{t:40},
-  },{responsive:true});
+  },{responsive:true,staticPlot:true,displayModeBar:false,scrollZoom:false,doubleClick:false});
 
   updateScenarioComparison();
 }
@@ -145,7 +145,7 @@ export function updateScenarioComparison(){
     yaxis:{title:'Projected\u00A0Value\u00A0($)'},
     legend:{orientation:'h',x:0.5,xanchor:'center',y:-0.3},
     margin:{t:40},
-  },{responsive:true});
+  },{responsive:true,staticPlot:true,displayModeBar:false,scrollZoom:false,doubleClick:false});
 
   const tbody=document.getElementById('projectionBody');
   tbody.innerHTML='';


### PR DESCRIPTION
## Summary
- replace Plotly config on main chart with non-interactive settings
- do the same for the scenario chart

## Testing
- `node --check js/calculator.js`


------
https://chatgpt.com/codex/tasks/task_e_68976b8da4108326b4130513ac9d620e