### PR TITLE
Add CSV export for projected projection table

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,6 +239,7 @@
                     <tbody id="projectionBody"></tbody>
                   </table>
                 </div>
+                <button id="exportProjectionCSV" class="btn" type="button">Export Projection CSV</button>
               </div>
             </div>
           </div>

--- a/js/ui.js
+++ b/js/ui.js
@@ -233,7 +233,23 @@ function exportDetailedTable(){
   URL.revokeObjectURL(link.href);
 }
 
+function exportProjectionTable(){
+  const rows=[...document.querySelectorAll('#projectionTable tr')];
+  const csv=rows.map(r=>
+    [...r.querySelectorAll('th,td')]
+      .map(c=>`"${c.innerText.replace(/"/g,'""')}"`)
+      .join(',')
+  ).join('\n');
+  const blob=new Blob([csv],{type:'text/csv'});
+  const link=document.createElement('a');
+  link.href=URL.createObjectURL(blob);
+  link.download='projection.csv';
+  link.click();
+  URL.revokeObjectURL(link.href);
+}
+
   document.getElementById('exportCSV').addEventListener('click',exportDetailedTable);
+  document.getElementById('exportProjectionCSV').addEventListener('click',exportProjectionTable);
 
 function downloadMainChart(){
   Plotly.downloadImage(document.getElementById('chart'),{


### PR DESCRIPTION
## Summary
- Add "Export Projection CSV" button to Projected Growth tab
- Implement `exportProjectionTable` for projection table CSV downloads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68976bc04ccc83268a2a57efc68a61f9