### PR TITLE
Add smooth animations and tab fade effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   <div class="container-fluid mt-4">
     <ul class="nav nav-tabs rounded-tabs flex-nowrap overflow-auto" id="dashboardTabs" role="tablist">
       <li class="nav-item">
-        <button class="nav-link active" id="historical-tab"
+        <button class="nav-link" id="historical-tab"
                 data-bs-toggle="tab" data-bs-target="#historical"
                 type="button" role="tab">
           Historical Performance
@@ -57,7 +57,7 @@
       <!-- ════════════════════════════════════════════════════
            HISTORICAL PERFORMANCE TAB
       ════════════════════════════════════════════════════ -->
-      <div class="tab-pane fade show active" id="historical" role="tabpanel" aria-labelledby="historical-tab">
+      <div class="tab-pane fade" id="historical" role="tabpanel" aria-labelledby="historical-tab">
         <div class="row mt-4">
           <!-- Investment Input Panel -->
           <div class="col-lg-4 mb-4">

--- a/js/main.js
+++ b/js/main.js
@@ -5,6 +5,10 @@ async function init(){
   try{
     await loadData();
     buildUI();
+    const firstTabEl=document.querySelector('#historical-tab');
+    if(firstTabEl){
+      new bootstrap.Tab(firstTabEl).show();
+    }
   }catch(err){
     console.error('Failed to load data',err);
     const sliderTable=document.getElementById('sliderTable');

--- a/styles.css
+++ b/styles.css
@@ -12,6 +12,12 @@ body {
   color: #212529;
 }
 
+/* Smooth background & shadow transitions */
+.btn,
+.nav-link {
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+
 /* Banner */
 .big-navbar {
   padding: 1.25rem 1rem;
@@ -47,6 +53,13 @@ body {
 /* Cards & tables */
 .card {
   margin-bottom: 1rem;
+  transition: background-color 0.3s ease, box-shadow 0.3s ease,
+    transform 0.3s ease;
+}
+
+.card:hover {
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  transform: translateY(-2px);
 }
 .table thead th {
   background: var(--main-green) !important;


### PR DESCRIPTION
## Summary
- Animate background and shadow changes on cards, buttons, and nav links for smoother interactions.
- Introduce a light hover shadow and lift on cards.
- Programmatically show the first tab so all panes use Bootstrap's fade transitions.

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897b093de408326b335058d122ac0d7