### PR TITLE
Use Bootstrap Icons for dashboard buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
   <!-- Bootstrap -->
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"/>
+  <!-- Bootstrap Icons -->
+  <link rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"/>
   <!-- Custom styles -->
   <link rel="stylesheet" href="styles.css" />
   <!-- Plotly -->
@@ -107,7 +110,9 @@
               <div class="card-body d-flex flex-column">
                 <h2 class="card-title">Stock Value Over Time</h2>
                 <div id="chart" style="width:100%;height:450px;"></div>
-                <button id="downloadMainChart" class="btn btn-secondary mt-2">Download Chart</button>
+                <button id="downloadMainChart" class="btn btn-secondary mt-2">
+                  <i class="bi bi-download"></i> Download Chart
+                </button>
                 <div id="roiChart" style="width:100%;height:450px;" class="mt-3"></div>
 
                 <div id="summaryScrollContainer"
@@ -162,7 +167,9 @@
                   </table>
                 </div>
 
-                <button id="exportCSV" class="btn" type="button">Export to CSV</button>
+                <button id="exportCSV" class="btn" type="button">
+                  <i class="bi bi-download"></i> Export to CSV
+                </button>
 
                 <div class="mt-3 text-muted small">
                   <strong>Notes:</strong>
@@ -225,7 +232,9 @@
                 <h2 class="card-title">Projected Growth</h2>
                 <div id="scenarioChart"
                      style="width:100%;height:450px;"></div>
-                <button id="downloadProjectionChart" class="btn btn-secondary mt-2">Download Chart</button>
+                <button id="downloadProjectionChart" class="btn btn-secondary mt-2">
+                  <i class="bi bi-download"></i> Download Chart
+                </button>
 
                 <div class="table-responsive mt-3 flex-grow-1">
                   <table id="projectionTable" class="table table-bordered mb-0">
@@ -240,7 +249,9 @@
                     <tbody id="projectionBody"></tbody>
                   </table>
                 </div>
-                <button id="exportProjectionCSV" class="btn" type="button">Export Projection CSV</button>
+                <button id="exportProjectionCSV" class="btn" type="button">
+                  <i class="bi bi-download"></i> Export Projection CSV
+                </button>
               </div>
             </div>
           </div>
@@ -250,8 +261,12 @@
 
     <!-- Navigation Buttons -->
     <div class="d-flex justify-content-end gap-2 mt-3">
-      <button id="goToDetailsBtn" class="btn btn-secondary">Go to Details</button>
-      <button id="goToProjectionBtn" class="btn btn-secondary">Go to Projected Growth</button>
+      <button id="goToDetailsBtn" class="btn btn-secondary">
+        <i class="bi bi-arrow-right-circle"></i> Go to Details
+      </button>
+      <button id="goToProjectionBtn" class="btn btn-secondary">
+        <i class="bi bi-arrow-right-circle"></i> Go to Projected Growth
+      </button>
     </div>
   </div><!-- /container -->
 

--- a/styles.css
+++ b/styles.css
@@ -179,3 +179,8 @@ footer {
   margin-top: 2rem;
   color: var(--main-gray);
 }
+
+/* Icon spacing */
+.btn i {
+  margin-right: .25rem;
+}


### PR DESCRIPTION
## Summary
- load Bootstrap Icons via CDN to support iconography
- add download and navigation icons to various buttons
- tweak button styling for icon spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b0961fa88326b348adcbcb69251a