### PR TITLE
Use Inter font for cleaner typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
   <!-- Bootstrap -->
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"/>
+  <!-- Google Fonts -->
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet"/>
   <!-- Custom styles -->
   <link rel="stylesheet" href="styles.css" />
   <!-- Plotly -->

--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,7 @@
 
 /* Global */
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Inter', Arial, sans-serif;
   background: #f8f9fa;
   color: #212529;
 }
@@ -21,6 +21,11 @@ body {
 }
 .navbar-brand {
   color: var(--main-green) !important;
+  font-weight: 700;
+}
+
+.card-title {
+  font-weight: 600;
 }
 
 /* Tabs */


### PR DESCRIPTION
## Summary
- load the Inter font from Google Fonts ahead of custom styles
- use Inter as the base typeface and increase heading weights for navbar and card titles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b43a02d08326ba7c2dcbcda73017