### PR TITLE
Add reusable blue button class and unify export button styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
   <!-- Bootstrap -->
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"/>
+  <!-- Bootstrap Icons -->
+  <link rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"/>
   <!-- Custom styles -->
   <link rel="stylesheet" href="styles.css" />
   <!-- Plotly -->
@@ -31,7 +34,7 @@
   <div class="container-fluid mt-4">
     <ul class="nav nav-tabs rounded-tabs flex-nowrap overflow-auto" id="dashboardTabs" role="tablist">
       <li class="nav-item">
-        <button class="nav-link active" id="historical-tab"
+        <button class="nav-link" id="historical-tab"
                 data-bs-toggle="tab" data-bs-target="#historical"
                 type="button" role="tab">
           Historical Performance
@@ -57,7 +60,7 @@
       <!-- ════════════════════════════════════════════════════
            HISTORICAL PERFORMANCE TAB
       ════════════════════════════════════════════════════ -->
-      <div class="tab-pane fade show active" id="historical" role="tabpanel" aria-labelledby="historical-tab">
+      <div class="tab-pane fade" id="historical" role="tabpanel" aria-labelledby="historical-tab">
         <div class="row mt-4">
           <!-- Investment Input Panel -->
           <div class="col-lg-4 mb-4">
@@ -107,7 +110,9 @@
               <div class="card-body d-flex flex-column">
                 <h2 class="card-title">Stock Value Over Time</h2>
                 <div id="chart" style="width:100%;height:450px;"></div>
-                <button id="downloadMainChart" class="btn btn-blue mt-2">Download Chart</button>
+                <button id="downloadMainChart" class="btn btn-blue mt-2">
+                  <i class="bi bi-download"></i> Download Chart
+                </button>
                 <div id="roiChart" style="width:100%;height:450px;" class="mt-3"></div>
 
                 <div id="summaryScrollContainer"
@@ -162,7 +167,9 @@
                   </table>
                 </div>
 
-                <button id="exportCSV" class="btn" type="button">Export to CSV</button>
+                <button id="exportCSV" class="btn" type="button">
+                  <i class="bi bi-download"></i> Export to CSV
+                </button>
 
                 <div class="mt-3 text-muted small">
                   <strong>Notes:</strong>
@@ -225,7 +232,9 @@
                 <h2 class="card-title">Projected Growth</h2>
                 <div id="scenarioChart"
                      style="width:100%;height:450px;"></div>
-                <button id="downloadProjectionChart" class="btn btn-blue mt-2">Download Chart</button>
+                <button id="downloadProjectionChart" class="btn btn-blue mt-2">
+                  <i class="bi bi-download"></i> Download Chart
+                </button>
 
                 <div class="table-responsive mt-3 flex-grow-1">
                   <table id="projectionTable" class="table table-bordered mb-0">
@@ -240,7 +249,9 @@
                     <tbody id="projectionBody"></tbody>
                   </table>
                 </div>
-                <button id="exportProjectionCSV" class="btn" type="button">Export Projection CSV</button>
+                <button id="exportProjectionCSV" class="btn" type="button">
+                  <i class="bi bi-download"></i> Export Projection CSV
+                </button>
               </div>
             </div>
           </div>
@@ -250,8 +261,12 @@
 
     <!-- Navigation Buttons -->
     <div class="d-flex justify-content-end gap-2 mt-3">
-      <button id="goToDetailsBtn" class="btn btn-secondary">Go to Details</button>
-      <button id="goToProjectionBtn" class="btn btn-secondary">Go to Projected Growth</button>
+      <button id="goToDetailsBtn" class="btn btn-secondary">
+        <i class="bi bi-arrow-right-circle"></i> Go to Details
+      </button>
+      <button id="goToProjectionBtn" class="btn btn-secondary">
+        <i class="bi bi-arrow-right-circle"></i> Go to Projected Growth
+      </button>
     </div>
   </div><!-- /container -->
 

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
                 <!-- Snap Button -->
                 <div class="mb-3">
                   <button id="snapBtn"
-                          class="btn btn-secondary w-100">
+                          class="btn btn-blue w-100">
                     Snap Investments to Stock Price
                   </button>
                 </div>
@@ -107,7 +107,7 @@
               <div class="card-body d-flex flex-column">
                 <h2 class="card-title">Stock Value Over Time</h2>
                 <div id="chart" style="width:100%;height:450px;"></div>
-                <button id="downloadMainChart" class="btn btn-secondary mt-2">Download Chart</button>
+                <button id="downloadMainChart" class="btn btn-blue mt-2">Download Chart</button>
                 <div id="roiChart" style="width:100%;height:450px;" class="mt-3"></div>
 
                 <div id="summaryScrollContainer"
@@ -225,7 +225,7 @@
                 <h2 class="card-title">Projected Growth</h2>
                 <div id="scenarioChart"
                      style="width:100%;height:450px;"></div>
-                <button id="downloadProjectionChart" class="btn btn-secondary mt-2">Download Chart</button>
+                <button id="downloadProjectionChart" class="btn btn-blue mt-2">Download Chart</button>
 
                 <div class="table-responsive mt-3 flex-grow-1">
                   <table id="projectionTable" class="table table-bordered mb-0">

--- a/js/main.js
+++ b/js/main.js
@@ -5,6 +5,10 @@ async function init(){
   try{
     await loadData();
     buildUI();
+    const firstTabEl=document.querySelector('#historical-tab');
+    if(firstTabEl){
+      new bootstrap.Tab(firstTabEl).show();
+    }
   }catch(err){
     console.error('Failed to load data',err);
     const sliderTable=document.getElementById('sliderTable');

--- a/styles.css
+++ b/styles.css
@@ -12,6 +12,12 @@ body {
   color: #212529;
 }
 
+/* Smooth background & shadow transitions */
+.btn,
+.nav-link {
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+
 /* Banner */
 .big-navbar {
   padding: 1.25rem 1rem;
@@ -47,6 +53,13 @@ body {
 /* Cards & tables */
 .card {
   margin-bottom: 1rem;
+  transition: background-color 0.3s ease, box-shadow 0.3s ease,
+    transform 0.3s ease;
+}
+
+.card:hover {
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  transform: translateY(-2px);
 }
 .table thead th {
   background: var(--main-green) !important;
@@ -192,4 +205,9 @@ footer {
   text-align: center;
   margin-top: 2rem;
   color: var(--main-gray);
+}
+
+/* Icon spacing */
+.btn i {
+  margin-right: .25rem;
 }

--- a/styles.css
+++ b/styles.css
@@ -84,12 +84,14 @@ body {
   overflow: hidden;
 }
 
-/* Preset (blue) button styles */
+/* Blue button styles */
+.btn-blue,
 .preset-btn {
   background: var(--main-blue);
-  border: 1px solid var(--main-blue);
+  border-color: var(--main-blue);
   color: #fff;
 }
+.btn-blue:hover,
 .preset-btn:hover {
   background: #0056b3;
   border-color: #0056b3;
@@ -98,14 +100,16 @@ body {
 /* Magenta action button styles */
 #goToDetailsBtn,
 #goToProjectionBtn,
-#exportCSV {
+#exportCSV,
+#exportProjectionCSV {
   background: var(--main-magenta);
   border-color: var(--main-magenta);
   color: #fff;
 }
 #goToDetailsBtn:hover,
 #goToProjectionBtn:hover,
-#exportCSV:hover {
+#exportCSV:hover,
+#exportProjectionCSV:hover {
   opacity: 0.75;
   color: #fff;
 }

--- a/styles.css
+++ b/styles.css
@@ -85,13 +85,23 @@ body {
 }
 
 /* Blue button styles */
-.btn-blue,
-.preset-btn {
+.btn-blue {
   background: var(--main-blue);
   border-color: var(--main-blue);
   color: #fff;
 }
-.btn-blue:hover,
+.btn-blue:hover {
+  background: #0056b3;
+  border-color: #0056b3;
+  color: #fff;
+}
+
+/* Preset (blue) button styles */
+.preset-btn {
+  background: var(--main-blue);
+  border: 1px solid var(--main-blue);
+  color: #fff;
+}
 .preset-btn:hover {
   background: #0056b3;
   border-color: #0056b3;


### PR DESCRIPTION
## Summary
- Add shared `.btn-blue` CSS class using the main blue palette and apply it to the snap and chart download buttons
- Give both CSV export buttons the same magenta styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b43b4ee083268eb78f4e884f96f0