### PR TITLE
feat: integrate Inter font for cleaner typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,10 @@
   <!-- Bootstrap Icons -->
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"/>
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet"/>
   <!-- Custom styles -->
   <link rel="stylesheet" href="styles.css" />
   <!-- Plotly -->

--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,7 @@
 
 /* Global */
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Inter', Arial, sans-serif;
   background: #f8f9fa;
   color: #212529;
 }
@@ -27,6 +27,11 @@ body {
 }
 .navbar-brand {
   color: var(--main-green) !important;
+  font-weight: 700;
+}
+
+.card-title {
+  font-weight: 600;
 }
 
 /* Tabs */


### PR DESCRIPTION
## Summary
- load Inter from Google Fonts for broader weight support
- use Inter as default font
- strengthen heading weights for crisper UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b9a999ac8326ae74dffc18b9a845