### PR TITLE
Ensure charts resize when historical tab is shown

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,6 @@
 import { loadData } from './data.js';
 import { buildUI } from './ui.js';
+import { updateCalculation } from './calculator.js';
 
 async function init(){
   try{
@@ -8,6 +9,13 @@ async function init(){
     const firstTabEl=document.querySelector('#historical-tab');
     if(firstTabEl){
       new bootstrap.Tab(firstTabEl).show();
+      updateCalculation();
+      firstTabEl.addEventListener('shown.bs.tab', () => {
+        const chart=document.getElementById('chart');
+        const roiChart=document.getElementById('roiChart');
+        if(chart) Plotly.Plots.resize(chart);
+        if(roiChart) Plotly.Plots.resize(roiChart);
+      });
     }
   }catch(err){
     console.error('Failed to load data',err);


### PR DESCRIPTION
## Summary
- import updateCalculation in main entry script
- trigger updateCalculation after showing the historical tab and resize charts when the tab is reactivated

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689932532200832680b9011b0694d1c5