### PR TITLE
Refactor snap button into preset panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,14 +75,6 @@
                   Purchases assumed to be in April of the following year at the new stock price
                 </p>
 
-                <!-- Snap Button -->
-                <div class="mb-3">
-                  <button id="snapBtn"
-                          class="btn btn-secondary w-100">
-                    Snap Investments to Stock Price
-                  </button>
-                </div>
-
                 <!-- Preset Buttons -->
                 <div id="presetPanel" class="mb-3">
                   <h6>Preset Investments ($100,000 investment)</h6>

--- a/js/ui.js
+++ b/js/ui.js
@@ -56,11 +56,22 @@ function generatePresets(){
     panel.appendChild(b);
   });
 
+  const controlRow=document.createElement('div');
+  controlRow.className='d-flex gap-2 mb-2';
+
+  const snap=document.createElement('button');
+  snap.id='snapBtn';
+  snap.className='btn btn-secondary flex-fill';
+  snap.textContent='Snap\u00A0Investments\u00A0to\u00A0Stock\u00A0Price';
+
   const clr=document.createElement('button');
   clr.id='clearBtn';
-  clr.className='btn btn-outline-secondary ms-2 mb-2';
+  clr.className='btn btn-outline-secondary flex-fill';
   clr.textContent='Clear\u00A0All\u00A0Values';
-  panel.appendChild(clr);
+
+  controlRow.appendChild(snap);
+  controlRow.appendChild(clr);
+  panel.appendChild(controlRow);
 
   panel.querySelectorAll('.preset-btn').forEach(btn=>{
     btn.addEventListener('click',e=>{
@@ -155,6 +166,19 @@ export function buildUI(){
   });
 
   generatePresets();
+
+  document.getElementById('snapBtn').addEventListener('click',()=>{
+    historicalData.forEach((rec,i)=>{
+      const raw=investmentAmounts[i];
+      const snap=Math.round(raw/rec.price)*rec.price;
+      investmentAmounts[i]=snap;
+      document.getElementById(`slider-${rec.year}`).value=snap;
+      document.getElementById(`number-${rec.year}`).value=fmtCur(snap);
+    });
+    updateCalculation();
+    saveInvestments();
+  });
+
   updateCalculation();
   updateScenarioComparison();
 }
@@ -173,18 +197,6 @@ export function applyToSubsequentYears(startIdx){
 }
 
 window.applyToSubsequentYears=applyToSubsequentYears;
-
-document.getElementById('snapBtn').addEventListener('click',()=>{
-  historicalData.forEach((rec,i)=>{
-    const raw=investmentAmounts[i];
-    const snap=Math.round(raw/rec.price)*rec.price;
-    investmentAmounts[i]=snap;
-    document.getElementById(`slider-${rec.year}`).value=snap;
-    document.getElementById(`number-${rec.year}`).value=fmtCur(snap);
-  });
-  updateCalculation();
-  saveInvestments();
-});
 
 document.getElementById('goToDetailsBtn').addEventListener('click',()=>{
   new bootstrap.Tab(document.getElementById('detailed-tab')).show();


### PR DESCRIPTION
## Summary
- Remove static Snap button markup from the main page
- Dynamically render Snap and Clear buttons inside the preset panel
- Attach Snap button handler after preset buttons are generated

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899334a5fa483268c95b74197e5314d