### PR TITLE
Add mobile styles for slider table

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -177,6 +177,17 @@ body {
   max-width: 100px;     /* prevents it from stretching in wide screens */
 }
 
+@media (max-width: 576px) {
+  #sliderTable th,
+  #sliderTable td {
+    padding: 0.25rem;
+    font-size: 0.875rem;
+  }
+  #sliderTable .currency-input {
+    width: 4rem;
+  }
+}
+
 /* Prevent the chart/table column from forcing a wrap */
 .projected-chart-col { min-width: 0; }
 


### PR DESCRIPTION
## Summary
- Add mobile-focused media query to shrink slider table cell padding and font size
- Narrow currency input fields to 4rem on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689934b87e1883269a070e8e22c3769b