### PR TITLE
Wrap slider table headers and tighten spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 
                 <!-- Slider Table -->
                 <div id="sliderScrollContainer" class="flex-grow-1">
-                  <table class="table table-striped mb-0">
+                  <table id="sliderTable" class="table table-striped table-sm mb-0">
                     <thead>
                       <tr>
                         <th>Financial Year</th>
@@ -93,7 +93,7 @@
                         <th class="two-line">Apply to All<br/>Following Year</th>
                       </tr>
                     </thead>
-                    <tbody id="sliderTable"></tbody>
+                    <tbody id="sliderTableBody"></tbody>
                   </table>
                 </div>
               </div>

--- a/js/main.js
+++ b/js/main.js
@@ -19,7 +19,7 @@ async function init(){
     }
   }catch(err){
     console.error('Failed to load data',err);
-    const sliderTable=document.getElementById('sliderTable');
+    const sliderTable=document.getElementById('sliderTableBody');
     sliderTable.innerHTML='<tr><td colspan="5">Data load failed.</td></tr>';
   }
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,7 +1,7 @@
 import { historicalData } from './data.js';
 import { fmtCur, fmtPrice, updateCalculation, updateScenarioComparison, investmentAmounts, resetInvestmentAmounts } from './calculator.js';
 
-const sliderTable=document.getElementById('sliderTable');
+const sliderTable=document.getElementById('sliderTableBody');
 const STORAGE_INVEST='investmentAmounts';
 const STORAGE_PROJ='projectionParams';
 

--- a/styles.css
+++ b/styles.css
@@ -181,6 +181,17 @@ body {
   white-space: normal;
 }
 
+@media (max-width: 576px) {
+  #sliderTable th,
+  #sliderTable td {
+    padding: 0.25rem;
+    font-size: 0.875rem;
+  }
+  #sliderTable .currency-input {
+    width: 4rem;
+  }
+}
+
 /* Prevent the chart/table column from forcing a wrap */
 .projected-chart-col { min-width: 0; }
 

--- a/styles.css
+++ b/styles.css
@@ -177,6 +177,10 @@ body {
   max-width: 100px;     /* prevents it from stretching in wide screens */
 }
 
+#sliderTable thead th {
+  white-space: normal;
+}
+
 /* Prevent the chart/table column from forcing a wrap */
 .projected-chart-col { min-width: 0; }
 


### PR DESCRIPTION
## Summary
- Allow slider table headers to wrap by applying `white-space: normal` to header cells.
- Use Bootstrap's `table-sm` on the slider table and update element IDs so JS references remain correct.

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `npx playwright --version` *(fails: 403 Forbidden)*
- `pip install selenium` *(fails: Could not find a version; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689934b7df7883268fe7f95c37e9dab0