### PR TITLE
Allow table headers to wrap

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,11 +86,11 @@
                   <table class="table table-striped mb-0">
                     <thead>
                       <tr>
-                        <th>Financial Year</th>
-                        <th>Stock Price</th>
+                        <th>Financial Year</th>
+                        <th>Stock Price</th>
                         <th>Purchase</th>
                         <th>Amount</th>
-                        <th class="two-line">Apply to All<br/>Following Year</th>
+                        <th>Apply to All Following Year</th>
                       </tr>
                     </thead>
                     <tbody id="sliderTable"></tbody>
@@ -116,9 +116,9 @@
                   <table id="summaryTable" class="table table-bordered mb-0">
                     <thead>
                       <tr>
-                        <th>Financial Year</th><th>Price</th>
-                        <th>Cumulative Invested</th>
-                        <th>Total Value</th><th>S&amp;P 500</th>
+                        <th>Financial Year</th><th>Price</th>
+                        <th>Cumulative Invested</th>
+                        <th>Total Value</th><th>S&amp;P 500</th>
                       </tr>
                     </thead>
                     <tbody id="summaryBody"></tbody>
@@ -143,20 +143,20 @@
                   <table id="detailedTable" class="table table-bordered">
                     <thead>
                       <tr>
-                        <th>Financial Year</th><th>Stock Price</th>
-                        <th>Invested<br/>This Year</th>
-                        <th>Cumulative<br/>Invested</th>
-                        <th>Employee<br/>Shares (Year)</th>
-                        <th>Cumulative<br/>Employee Shares</th>
-                        <th>Match Awarded<br/>This Year (#)</th>
-                        <th>Cumulative<br/>Match Awarded (#)</th>
-                        <th>Cumulative<br/>Match Awarded</th>
-                        <th>Employee<br/>Value</th>
-                        <th>Match<br/>Value</th>
-                        <th>Total<br/>Value</th>
-                        <th>S&amp;P 500</th>
-                        <th>S&amp;P Price</th>
-                        <th>ROI (%)</th>
+                        <th>Financial Year</th><th>Stock Price</th>
+                        <th>Invested This Year</th>
+                        <th>Cumulative Invested</th>
+                        <th>Employee Shares (Year)</th>
+                        <th>Cumulative Employee Shares</th>
+                        <th>Match Awarded This Year (#)</th>
+                        <th>Cumulative Match Awarded (#)</th>
+                        <th>Cumulative Match Awarded</th>
+                        <th>Employee Value</th>
+                        <th>Match Value</th>
+                        <th>Total Value</th>
+                        <th>S&amp;P 500</th>
+                        <th>S&amp;P Price</th>
+                        <th>ROI (%)</th>
                       </tr>
                     </thead>
                     <tbody id="detailedBody"></tbody>
@@ -236,7 +236,7 @@
                   <table id="projectionTable" class="table table-bordered mb-0">
                     <thead>
                       <tr>
-                        <th>Financial Year</th>
+                        <th>Financial Year</th>
                         <th>Conservative</th>
                         <th>Base</th>
                         <th>Aggressive</th>

--- a/styles.css
+++ b/styles.css
@@ -75,16 +75,12 @@ body {
 .table thead th {
   background: var(--main-green) !important;
   color: #fff;
+  white-space: normal;
+  word-break: break-word;
 }
 .table th,
 .table td {
   vertical-align: middle;
-}
-
-/* Two‑line header cell in slider table */
-.two-line {
-  line-height: 1.1;
-  white-space: normal;
 }
 
 /* Scrollable areas */


### PR DESCRIPTION
## Summary
- replace non-breaking spaces in table headers with normal spaces
- let table headers wrap by default via new global CSS rule
- remove special header-wrapping classes and manual `<br/>` breaks

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689938bb00288326b78129a2e4b8e10f