### PR TITLE
Format currency and share values

### DIFF
--- a/js/calculator.js
+++ b/js/calculator.js
@@ -1,7 +1,8 @@
 import { matchRate, vestingPeriod, historicalData, sp500Close } from './data.js';
 
-export const fmtCur = v => `$${Number(v).toLocaleString(undefined,{minimumFractionDigits:2,maximumFractionDigits:2})}`;
+export const fmtCur = v => `$${Number(v).toLocaleString(undefined,{maximumFractionDigits:0})}`;
 export const fmtPrice = v => `$${Number(v).toFixed(3)}`;
+export const fmtNum = v => Number(v).toLocaleString(undefined,{maximumFractionDigits:0});
 
 export let investmentAmounts = [];
 export let finalTotalValue = 0;
@@ -61,8 +62,8 @@ export function updateCalculation(){
       <tr>
         <td>${rec.year}</td><td>${fmtPrice(price)}</td>
         <td>${fmtCur(invest)}</td><td>${fmtCur(cumInvest)}</td>
-        <td>${empShares.toFixed(2)}</td><td>${cumShares.toFixed(2)}</td>
-        <td>${matchThis}</td><td>${cumMatchShares}</td>
+        <td>${fmtNum(empShares)}</td><td>${fmtNum(cumShares)}</td>
+        <td>${fmtNum(matchThis)}</td><td>${fmtNum(cumMatchShares)}</td>
         <td>${fmtCur(matchThis*price)}</td>
         <td>${fmtCur(valEmp)}</td><td>${fmtCur(valMatch)}</td>
         <td>${fmtCur(totalVal)}</td><td>${fmtCur(spVal)}</td>

--- a/js/ui.js
+++ b/js/ui.js
@@ -108,7 +108,7 @@ export function buildUI(){
   if(storedProj.aggressiveRate!==undefined) aggr.value=storedProj.aggressiveRate;
   if(storedProj.annualPurchase!==undefined){
     const ap=parseFloat(storedProj.annualPurchase)||0;
-    annual.value=fmtCur(ap).replace('.00','');
+    annual.value=fmtCur(ap);
   }
 
   historicalData.forEach((rec,idx)=>{
@@ -221,7 +221,7 @@ annualInput.addEventListener('focus',e=>{
 });
 annualInput.addEventListener('blur',e=>{
   const v=parseFloat(e.target.value.replace(/[^0-9.]/g,''))||0;
-  e.target.value=fmtCur(v).replace('.00','');
+  e.target.value=fmtCur(v);
   updateScenarioComparison();
   saveProjectionParams();
 });


### PR DESCRIPTION
## Summary
- Remove cents from all displayed currency values, leaving stock price formatting untouched for early-year precision.
- Show stock counts with comma separators and no decimals in the detailed table.
- Annual purchase inputs now render as whole-dollar amounts.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68993a3a200c8326a09bf244b614101a