### PR TITLE
Improve ROI secondary axis tick marks

### DIFF
--- a/js/calculator.js
+++ b/js/calculator.js
@@ -93,7 +93,7 @@ export function updateCalculation(){
   ],{
     xaxis:{dtick:1,title:'Financial\u00A0Year'},
     yaxis:{title:'Value\u00A0($)'},
-    yaxis2:{title:'ROI\u00A0(%)',overlaying:'y',side:'right',showgrid:false},
+    yaxis2:{title:'ROI\u00A0(%)',overlaying:'y',side:'right',showgrid:false,tick0:0,dtick:100},
     legend:{orientation:'h',x:0,xanchor:'left',y:-.25},
     margin:{t:40},
   },{responsive:true,staticPlot:true,displayModeBar:false,scrollZoom:false,doubleClick:false});


### PR DESCRIPTION
## Summary
- add regular 100% tick spacing on ROI secondary axis for clearer reference

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68993b6230a88326bb03ed3f28521b09