### PR TITLE
fix: refine table header wrapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,7 +231,7 @@
                   <i class="bi bi-download"></i> Download Chart
                 </button>
 
-                <div class="table-responsive mt-3 flex-grow-1">
+                <div class="mt-3 flex-grow-1">
                   <table id="projectionTable" class="table table-bordered mb-0">
                     <thead>
                       <tr>

--- a/styles.css
+++ b/styles.css
@@ -75,18 +75,23 @@ body {
 .table thead th {
   background: var(--main-green) !important;
   color: #fff;
-  white-space: normal;
-  word-break: break-word;
+  white-space: normal; /* allow wrapping between words */
+  word-break: keep-all; /* prevent breaking within words */
 }
 .table th,
 .table td {
   vertical-align: middle;
 }
 
+#sliderTable th {
+  font-size: 0.85rem;
+}
+
 /* Scrollable areas */
 #sliderScrollContainer {
   /*max-height: 700px;*/
   overflow-y: auto;
+  overflow-x: hidden; /* avoid horizontal scroll in main input table */
 }
 #summaryScrollContainer {
   /*max-height: 700px;*/


### PR DESCRIPTION
## Summary
- allow table headers to wrap at word boundaries without splitting words
- disable horizontal scrolling on main input and projection tables while keeping it for the details table

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68993f3d5b8483269d78ce94670af7e4