### PR TITLE
Prevent snap button from submitting form

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -60,9 +60,22 @@ function generatePresets(){
   controlRow.className='d-flex gap-2 mb-2';
 
   const snap=document.createElement('button');
+  snap.type='button';
   snap.id='snapBtn';
   snap.className='btn btn-secondary flex-fill';
   snap.textContent='Snap\u00A0Investments\u00A0to\u00A0Stock\u00A0Price';
+  snap.addEventListener('click',()=>{
+    historicalData.forEach((rec,i)=>{
+      const raw=Number(investmentAmounts[i]);
+      const snapVal=Math.round(raw/rec.price)*rec.price;
+      investmentAmounts[i]=snapVal;
+      document.getElementById(`slider-${rec.year}`).value=snapVal;
+      document.getElementById(`number-${rec.year}`).value=fmtCur(snapVal);
+    });
+    updateCalculation();
+    saveInvestments();
+    snap.blur();
+  });
 
   const clr=document.createElement('button');
   clr.id='clearBtn';
@@ -166,18 +179,6 @@ export function buildUI(){
   });
 
   generatePresets();
-
-  document.getElementById('snapBtn').addEventListener('click',()=>{
-    historicalData.forEach((rec,i)=>{
-      const raw=investmentAmounts[i];
-      const snap=Math.round(raw/rec.price)*rec.price;
-      investmentAmounts[i]=snap;
-      document.getElementById(`slider-${rec.year}`).value=snap;
-      document.getElementById(`number-${rec.year}`).value=fmtCur(snap);
-    });
-    updateCalculation();
-    saveInvestments();
-  });
 
   updateCalculation();
   updateScenarioComparison();


### PR DESCRIPTION
## Summary
- Avoid form submission by assigning `type="button"` to the Snap Investments button.
- Attach snap handler on creation, coercing values with `Number()` and blurring the button after snapping.

## Testing
- `npm test` *(fails: Could not read package.json)*
- Manually executed a Node script to confirm snapping rounds values to share-price multiples and clears button focus.

------
https://chatgpt.com/codex/tasks/task_e_689944f04d2483268a9a076b1491ab54