### PR TITLE
Adjust S&P500 growth to apply after market performance

### DIFF
--- a/js/calculator.js
+++ b/js/calculator.js
@@ -41,10 +41,11 @@ export function updateCalculation(){
     const totalVal=valEmp+valMatch;
 
     const spClose=sp500Close[idx].close;
-    if(idx===0) spVal=invest;
-    else{
+    if(idx>0){
       const prevClose=sp500Close[idx-1].close;
-      spVal=(spVal+invest)*(spClose/prevClose);
+      spVal=spVal*(spClose/prevClose)+invest;
+    }else{
+      spVal=invest;
     }
 
     summaryBody.insertAdjacentHTML('beforeend',`


### PR DESCRIPTION
## Summary
- Update S&P500 calculation so contributions are added after applying yearly market change.

## Testing
- `npm test` *(fails: could not read package.json)*
- `node` script verifying 2021 $18k contribution grows beginning in 2022

------
https://chatgpt.com/codex/tasks/task_e_689a00ef95008326b1fc2f9d6eadb6bd