### PR TITLE
Remove redundant scenario update during UI build

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -181,7 +181,6 @@ export function buildUI(){
   generatePresets();
 
   updateCalculation();
-  updateScenarioComparison();
 }
 
 export function applyToSubsequentYears(startIdx){


### PR DESCRIPTION
## Summary
- drop superfluous `updateScenarioComparison()` call in `buildUI`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a6d4bd4848326bac81cca94a3f1e3