### PR TITLE
refactor: centralize table export helper

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -231,8 +231,8 @@ annualInput.addEventListener('input',()=>{
   saveProjectionParams();
 });
 
-function exportDetailedTable(){
-  const rows=[...document.querySelectorAll('#detailedTable tr')];
+function exportTableToCSV(tableId,filename){
+  const rows=[...document.querySelectorAll(`#${tableId} tr`)];
   const csv=rows.map(r=>
     [...r.querySelectorAll('th,td')]
       .map(c=>`"${c.innerText.replace(/"/g,'""')}"`)
@@ -241,28 +241,13 @@ function exportDetailedTable(){
   const blob=new Blob([csv],{type:'text/csv'});
   const link=document.createElement('a');
   link.href=URL.createObjectURL(blob);
-  link.download='detailed.csv';
+  link.download=`${filename}.csv`;
   link.click();
   URL.revokeObjectURL(link.href);
 }
 
-function exportProjectionTable(){
-  const rows=[...document.querySelectorAll('#projectionTable tr')];
-  const csv=rows.map(r=>
-    [...r.querySelectorAll('th,td')]
-      .map(c=>`"${c.innerText.replace(/"/g,'""')}"`)
-      .join(',')
-  ).join('\n');
-  const blob=new Blob([csv],{type:'text/csv'});
-  const link=document.createElement('a');
-  link.href=URL.createObjectURL(blob);
-  link.download='projection.csv';
-  link.click();
-  URL.revokeObjectURL(link.href);
-}
-
-  document.getElementById('exportCSV').addEventListener('click',exportDetailedTable);
-  document.getElementById('exportProjectionCSV').addEventListener('click',exportProjectionTable);
+  document.getElementById('exportCSV').addEventListener('click',()=>exportTableToCSV('detailedTable','detailed'));
+  document.getElementById('exportProjectionCSV').addEventListener('click',()=>exportTableToCSV('projectionTable','projection'));
 
 function downloadMainChart(){
   Plotly.downloadImage(document.getElementById('chart'),{


### PR DESCRIPTION
## Summary
- add reusable `exportTableToCSV` helper for table CSV downloads
- wire detailed and projection table downloads through new helper

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_689a6d4d26c08326a17dcbd974bdc275