### PR TITLE
Refactor chart download handlers

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -264,17 +264,15 @@ function exportProjectionTable(){
   document.getElementById('exportCSV').addEventListener('click',exportDetailedTable);
   document.getElementById('exportProjectionCSV').addEventListener('click',exportProjectionTable);
 
-function downloadMainChart(){
-  Plotly.downloadImage(document.getElementById('chart'),{
-    format:'png',filename:'stock_value_over_time'
+function downloadChart(id,filename){
+  Plotly.downloadImage(document.getElementById(id),{
+    format:'png',filename
   });
 }
 
-function downloadProjectionChart(){
-  Plotly.downloadImage(document.getElementById('scenarioChart'),{
-    format:'png',filename:'projected_growth'
-  });
-}
-
-document.getElementById('downloadMainChart').addEventListener('click',downloadMainChart);
-document.getElementById('downloadProjectionChart').addEventListener('click',downloadProjectionChart);
+document.getElementById('downloadMainChart').addEventListener('click',()=>
+  downloadChart('chart','stock_value_over_time')
+);
+document.getElementById('downloadProjectionChart').addEventListener('click',()=>
+  downloadChart('scenarioChart','projected_growth')
+);


### PR DESCRIPTION
## Summary
- consolidate chart export logic into a generic `downloadChart` helper
- wire buttons to call the helper for main and scenario charts

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a6d54a1ec8326bf67aed19bf996f2