### PR TITLE
Use Plotly basic bundle for lighter charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Add a new object with the latest year and values to each array and keep the list
 ## Dependencies
 This project relies on the following libraries loaded via CDN in `index.html`:
 - [Bootstrap 5](https://getbootstrap.com/) – layout and components
-- [Plotly](https://plotly.com/javascript/) – interactive charts
+- [Plotly Basic](https://plotly.com/javascript/) – interactive charts
+
+*Limitations:* the Plotly basic bundle supports only core trace types such as scatter and bar charts. Specialized charts like 3D, geographic, or financial visualizations are not included.
 
 No additional build steps are required.
 

--- a/index.html
+++ b/index.html
@@ -17,8 +17,8 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet"/>
   <!-- Custom styles -->
   <link rel="stylesheet" href="styles.css" />
-  <!-- Plotly -->
-  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+  <!-- Plotly (basic bundle) -->
+  <script src="https://cdn.plot.ly/plotly-basic.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- replace full Plotly CDN with smaller `plotly-basic.min.js` bundle
- document Plotly basic bundle and its chart limitations

## Testing
- `npx -p playwright playwright install chromium` *(fails: 403 Forbidden when accessing npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_689a6f400870832680bb90066a3aa92f