### PR TITLE
Improve data fetch error handling

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -4,14 +4,25 @@ export const vestingPeriod = 5;  // match vests 5 years later
 export let historicalData = [];
 export let sp500Close = [];
 
-export async function loadData(){
-  const [histRes, spRes] = await Promise.all([
-    fetch('./data/history.json'),
-    fetch('./data/sp500.json')
-  ]);
-  if(!histRes.ok || !spRes.ok){
-    throw new Error('Failed to load data');
+async function fetchJson(url){
+  try{
+    const res=await fetch(url);
+    if(!res.ok){
+      throw new Error(`${res.status} ${res.statusText}`);
+    }
+    return await res.json();
+  }catch(err){
+    throw new Error(`${err.message} (${url})`);
   }
-  historicalData = await histRes.json();
-  sp500Close = await spRes.json();
+}
+
+export async function loadData(){
+  try{
+    [historicalData, sp500Close]=await Promise.all([
+      fetchJson('./data/history.json'),
+      fetchJson('./data/sp500.json')
+    ]);
+  }catch(err){
+    throw new Error(err.message);
+  }
 }

--- a/js/main.js
+++ b/js/main.js
@@ -18,9 +18,12 @@ async function init(){
       });
     }
   }catch(err){
-    console.error('Failed to load data',err);
+    const message=`Failed to load data: ${err.message}`;
+    console.error(message);
     const sliderTable=document.getElementById('sliderTable');
-    sliderTable.innerHTML='<tr><td colspan="5">Data load failed.</td></tr>';
+    if(sliderTable){
+      sliderTable.innerHTML=`<tr><td colspan="5">${message}</td></tr>`;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Wrap data fetches in try/catch and rethrow errors with message and URL
- Display detailed load errors in the UI and console

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a7d8fc6348326bb9b9476e30e6793