### PR TITLE
Allow Clear All Values button to wrap on small screens

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -57,7 +57,7 @@ function generatePresets(){
   });
 
   const controlRow=document.createElement('div');
-  controlRow.className='d-flex gap-2 mb-2';
+  controlRow.className='d-flex flex-wrap gap-2 mb-2';
 
   const snap=document.createElement('button');
   snap.type='button';


### PR DESCRIPTION
## Summary
- prevent Clear All Values button overflow by enabling flex wrapping for preset control row

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a858884ac8326b4431fd438a4ef3d