### PR TITLE
Use full Plotly bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ Add a new object with the latest year and values to each array and keep the list
 ## Dependencies
 This project relies on the following libraries loaded via CDN in `index.html`:
 - [Bootstrap 5](https://getbootstrap.com/) – layout and components
-- [Plotly Basic](https://plotly.com/javascript/) – interactive charts
-
-*Limitations:* the Plotly basic bundle supports only core trace types such as scatter and bar charts. Specialized charts like 3D, geographic, or financial visualizations are not included.
+- [Plotly.js](https://plotly.com/javascript/) – interactive charts
 
 No additional build steps are required.
 

--- a/index.html
+++ b/index.html
@@ -17,8 +17,8 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet"/>
   <!-- Custom styles -->
   <link rel="stylesheet" href="styles.css" />
-  <!-- Plotly (basic bundle) -->
-  <script src="https://cdn.plot.ly/plotly-basic.min.js"></script>
+  <!-- Plotly.js -->
+  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- Load Plotly.js full bundle instead of the basic bundle and update comments accordingly.
- Reflect Plotly.js in README dependencies and remove basic-bundle limitation note.

## Testing
- `node --check js/*.js`
- `curl -I http://localhost:8000/index.html`
- Attempted to fetch Plotly CDN: `curl https://cdn.plot.ly/plotly-latest.min.js` (403 Forbidden, unable to fully verify in-container)


------
https://chatgpt.com/codex/tasks/task_e_689a99484cc08326a3679dae0f584821