### PR TITLE
Lower projected annual purchase slider cap to $10k

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
                 <input id="annualPurchase" type="text"
                        class="form-control form-control-sm currency-input" value="$0"/>
                 <input id="annualPurchaseSlider" type="range" class="slider"
-                       min="0" max="100000" value="0"/>
+                       min="0" max="10000" value="0"/>
 
                 <label class="form-label mt-3" for="conservativeRate">Conservative Growth (%)</label>
                 <input id="conservativeRate" type="number"


### PR DESCRIPTION
## Summary
- limit projected annual purchase slider to $10,000 instead of $100,000

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689aaba8c1fc83268f2bf0df2db6040f