### PR TITLE
Set default projected growth rates to 6/10/14

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,15 +212,15 @@
 
                 <label class="form-label mt-3" for="baseRate">Base Growth (%)</label>
                 <input id="baseRate" type="number"
-                       class="form-control form-control-sm" value="19"/>
+                       class="form-control form-control-sm" value="10"/>
                 <input id="baseRateSlider" type="range" class="slider"
-                       min="0" max="30" value="19"/>
+                       min="0" max="30" value="10"/>
 
                 <label class="form-label mt-3" for="aggressiveRate">Aggressive Growth (%)</label>
                 <input id="aggressiveRate" type="number"
-                       class="form-control form-control-sm" value="27"/>
+                       class="form-control form-control-sm" value="14"/>
                 <input id="aggressiveRateSlider" type="range" class="slider"
-                       min="0" max="30" value="27"/>
+                       min="0" max="30" value="14"/>
 
                 <p class="text-muted small mt-4 mb-0">
                   Past performance is not a guarantee of future results.<br/>


### PR DESCRIPTION
## Summary
- Set projected growth defaults to 6%, 10%, and 14% for conservative, base, and aggressive scenarios.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b0fe13c0c83269c1cfbebddfc4247