### PR TITLE
Coerce investment inputs to numbers

### DIFF
--- a/js/calculator.js
+++ b/js/calculator.js
@@ -20,7 +20,7 @@ export function updateCalculation(){
   const yrs=[],invArr=[],empArr=[],totArr=[],spArr=[],roiArr=[];
 
   historicalData.forEach((rec,idx)=>{
-    const invest=investmentAmounts[idx];
+    const invest=Number(investmentAmounts[idx])||0;
     const price =rec.price;
     const empShares=invest/price;
     cumShares+=empShares;
@@ -28,7 +28,7 @@ export function updateCalculation(){
 
     let matchThis=0;
     if(idx>=vestingPeriod){
-      const invAgo=investmentAmounts[idx-vestingPeriod];
+      const invAgo=Number(investmentAmounts[idx-vestingPeriod])||0;
       if(invAgo>0){
         const priceAgo=historicalData[idx-vestingPeriod].price;
         matchThis=Math.round((invAgo/priceAgo)*matchRate);


### PR DESCRIPTION
## Summary
- Avoid NaN in calculation logic by coercing investment values to numbers

## Testing
- `node --input-type=module <<'NODE'
import { updateCalculation, resetInvestmentAmounts, investmentAmounts, finalTotalValue } from './js/calculator.js';
import { historicalData, sp500Close } from './js/data.js';

const elements = {
  summaryBody:{innerHTML:'',insertAdjacentHTML(pos,html){ this.innerHTML += html; }},
  detailedBody:{innerHTML:'',insertAdjacentHTML(pos,html){ this.innerHTML += html; }},
  projectionYears:{value:'2'},
  annualPurchase:{value:'100'},
  conservativeRate:{value:'5'},
  baseRate:{value:'8'},
  aggressiveRate:{value:'10'},
  projectionBody:{innerHTML:'',insertAdjacentHTML(pos,html){ this.innerHTML += html; }},
  scenarioChart:{}
};
global.document = { getElementById:id => elements[id] };
global.Plotly = { newPlot:()=>{} };

historicalData.splice(0,historicalData.length,
  {year:2000,price:10},
  {year:2001,price:12},
  {year:2002,price:14},
  {year:2003,price:16},
  {year:2004,price:18},
  {year:2005,price:20}
);
sp500Close.splice(0,sp500Close.length,
  {close:1000},
  {close:1050},
  {close:1100},
  {close:1150},
  {close:1200},
  {close:1250}
);

resetInvestmentAmounts(historicalData.length);
updateCalculation();
console.log('Scenario1 final', finalTotalValue, 'NaN?', Number.isNaN(finalTotalValue));

resetInvestmentAmounts(historicalData.length);
investmentAmounts[0]='abc';
investmentAmounts[2]=null;
investmentAmounts[5]='';
updateCalculation();
console.log('Scenario2 final', finalTotalValue, 'NaN?', Number.isNaN(finalTotalValue));
console.log('Summary has NaN?', elements.summaryBody.innerHTML.includes('NaN'));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689d163c33348326950ef16ea7b578ae