### PR TITLE
Limit download button width and unify projection export styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
               <div class="card-body d-flex flex-column">
                 <h2 class="card-title">Stock Value Over Time</h2>
                   <div id="chart" style="width:100%;height:450px;"></div>
-                  <button id="downloadMainChart" class="btn btn-secondary mt-2">
+                  <button id="downloadMainChart" class="btn btn-secondary mt-2 limited-btn">
                     <i class="bi bi-download"></i> Download Chart
                   </button>
 
@@ -237,7 +237,7 @@
                 <h2 class="card-title">Projected Growth</h2>
                 <div id="scenarioChart"
                      style="width:100%;height:450px;"></div>
-                <button id="downloadProjectionChart" class="btn btn-secondary mt-2">
+                <button id="downloadProjectionChart" class="btn btn-secondary mt-2 limited-btn">
                   <i class="bi bi-download"></i> Download Chart
                 </button>
 
@@ -254,7 +254,7 @@
                     <tbody id="projectionBody"></tbody>
                   </table>
                 </div>
-                <button id="exportProjectionCSV" class="btn" type="button">
+                <button id="exportProjectionCSV" class="btn limited-btn" type="button">
                   <i class="bi bi-download"></i> Export Projection CSV
                 </button>
               </div>

--- a/styles.css
+++ b/styles.css
@@ -120,16 +120,25 @@ body {
 /* Magenta action button styles */
 #goToDetailsBtn,
 #goToProjectionBtn,
-#exportCSV {
+#exportCSV,
+#exportProjectionCSV {
   background: var(--main-magenta);
   border-color: var(--main-magenta);
   color: #fff;
 }
 #goToDetailsBtn:hover,
 #goToProjectionBtn:hover,
-#exportCSV:hover {
+#exportCSV:hover,
+#exportProjectionCSV:hover {
   opacity: 0.75;
   color: #fff;
+}
+
+/* Limit width for buttons that should shrink on large screens */
+.limited-btn {
+  align-self: flex-start;
+  width: 100%;
+  max-width: 300px;
 }
 
 /* Slider */


### PR DESCRIPTION
## Summary
- cap download graph buttons at a reasonable width on larger screens
- style projection export button to match details tab

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d2d2c73c8832682cccef22d30558c