### PR TITLE
Add spacing above projection CSV export button

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
                     <tbody id="projectionBody"></tbody>
                   </table>
                 </div>
-                <button id="exportProjectionCSV" class="btn limited-btn" type="button">
+                <button id="exportProjectionCSV" class="btn limited-btn mt-3" type="button">
                   <i class="bi bi-download"></i> Export Projection CSV
                 </button>
               </div>


### PR DESCRIPTION
## Summary
- Add margin-top to the Projected Growth CSV export button for clearer separation from the table

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d33a9a17c832698732e541895e852