### PR TITLE
feat: raise slider max dynamically

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -109,6 +109,13 @@ export function buildUI(){
   const storedInvest=JSON.parse(localStorage.getItem(STORAGE_INVEST)||'[]');
   const storedProj=JSON.parse(localStorage.getItem(STORAGE_PROJ)||'{}');
 
+  // determine an appropriate slider ceiling. Use the largest preset (25k)
+  // and any stored investment, then add a small buffer so manual entries
+  // aren't immediately clamped.
+  const SLIDER_BASE_MAX = 25000; // largest preset value (front/late)
+  const SLIDER_BUFFER = 5000;    // allow some headroom for manual input
+  const sliderMax = Math.max(SLIDER_BASE_MAX, ...storedInvest) + SLIDER_BUFFER;
+
   // populate projection inputs if stored
   const projYears=document.getElementById('projectionYears');
   const cons=document.getElementById('conservativeRate');
@@ -163,7 +170,7 @@ export function buildUI(){
       <td>
         <div class="slidecontainer">
           <input type="range" class="slider" id="slider-${rec.year}"
-                 min="0" max="20000" step="any" value="${initVal}">
+                 min="0" max="${sliderMax}" step="any" value="${initVal}">
         </div>
       </td>
       <td><input type="text" id="number-${rec.year}"


### PR DESCRIPTION
## Summary
- dynamically compute slider max from largest preset (25k) and stored investments with a buffer
- ensure range inputs use this max to avoid clamping preset values

## Testing
- `node - <<'NODE'
const storedInvest=[0,0,0];
const SLIDER_BASE_MAX=25000;
const SLIDER_BUFFER=5000;
const sliderMax=Math.max(SLIDER_BASE_MAX,...storedInvest)+SLIDER_BUFFER;
console.log('sliderMax', sliderMax);

const recPrice=123.45;
let raw=25000;
let snap=Math.round(raw/recPrice)*recPrice;
console.log('snap for raw 25000', snap);
raw=26000;
snap=Math.round(raw/recPrice)*recPrice;
console.log('snap for raw 26000', snap);
NODE`
- `node - <<'NODE'
const sliderMax=30000;
const manual=26000;
console.log('manual capped', Math.min(manual, sliderMax));
NODE`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abadcbe29483269ff52bfbd002d5a0