### PR TITLE
Remove unused exports

### DIFF
--- a/js/calculator.js
+++ b/js/calculator.js
@@ -2,10 +2,10 @@ import { matchRate, vestingPeriod, historicalData, sp500Close } from './data.js'
 
 export const fmtCur = v => `$${Number(v).toLocaleString(undefined,{maximumFractionDigits:0})}`;
 export const fmtPrice = v => `$${Number(v).toFixed(3)}`;
-export const fmtNum = v => Number(v).toLocaleString(undefined,{maximumFractionDigits:0});
+const fmtNum = v => Number(v).toLocaleString(undefined,{maximumFractionDigits:0});
 
 export let investmentAmounts = [];
-export let finalTotalValue = 0;
+let finalTotalValue = 0;
 
 export function resetInvestmentAmounts(len){
   investmentAmounts = Array(len).fill(0);

--- a/js/ui.js
+++ b/js/ui.js
@@ -219,7 +219,7 @@ export function buildUI(){
   updateCalculation();
 }
 
-export function applyToSubsequentYears(startIdx){
+function applyToSubsequentYears(startIdx){
   const v=investmentAmounts[startIdx];
   historicalData.forEach((rec,i)=>{
     if(i>=startIdx){


### PR DESCRIPTION
## Summary
- Drop unused exports `fmtNum` and `finalTotalValue` from calculator module.
- Make `applyToSubsequentYears` an internal helper within UI module.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abb6e6a7d483268350b50a85ae25e7